### PR TITLE
fix(client): handle FreeBSD/BSDs in claude_desktop_config_path

### DIFF
--- a/crates/fastmcp-client/src/mcp_config.rs
+++ b/crates/fastmcp-client/src/mcp_config.rs
@@ -611,13 +611,18 @@ pub fn claude_desktop_config_path() -> Option<PathBuf> {
         dirs::data_dir().map(|d| d.join("Claude/claude_desktop_config.json"))
     }
 
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "linux", target_os = "freebsd", target_os = "netbsd", target_os = "openbsd", target_os = "dragonfly"))]
     {
         if let Ok(xdg_config) = env::var("XDG_CONFIG_HOME") {
             Some(PathBuf::from(xdg_config).join("claude/config.json"))
         } else {
             dirs::home_dir().map(|h| h.join(".config/claude/config.json"))
         }
+    }
+
+    #[cfg(not(any(target_os = "macos", target_os = "windows", target_os = "linux", target_os = "freebsd", target_os = "netbsd", target_os = "openbsd", target_os = "dragonfly")))]
+    {
+        None
     }
 }
 


### PR DESCRIPTION
## Summary

`claude_desktop_config_path()` in `crates/fastmcp-client/src/mcp_config.rs` had cfg-gated branches for macos, windows, and linux only. On FreeBSD (and the other BSDs) all three branches dead-strip, leaving an empty function body that returns `()` instead of `Option<PathBuf>`. Build error:

```
error[E0308]: mismatched types
   --> crates/fastmcp-client/src/mcp_config.rs:602:40
    |
602 | pub fn claude_desktop_config_path() -> Option<PathBuf> {
    |        --------------------------      ^^^^^^^^^^^^^^^ expected `Option<PathBuf>`, found `()`
    |        |
    |        implicitly returns `()` as its body has no tail or `return` expression
```

## Root cause

The function has three `#[cfg(target_os = "X")]` blocks and no fallback. On any target_os that isn't matched, the function compiles to nothing — which is a type error since the return type is `Option<PathBuf>`.

## Fix

Two changes:

1. **Widen the linux branch** to cover FreeBSD, NetBSD, OpenBSD, and DragonFly — all of which use the same `~/.config/claude/config.json` XDG-style convention as linux. No behavior change on linux; BSDs now produce the same path linux did.

2. **Add a fallback `None` arm** for any target_os that doesn't match macos, windows, linux, or the BSDs. This makes the function robust against adding a new top-level branch later without remembering to update gates here.

Diff:
```diff
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "linux", target_os = "freebsd", target_os = "netbsd", target_os = "openbsd", target_os = "dragonfly"))]
     {
         if let Ok(xdg_config) = env::var(\"XDG_CONFIG_HOME\") {
             Some(PathBuf::from(xdg_config).join(\"claude/config.json\"))
         } else {
             dirs::home_dir().map(|h| h.join(\".config/claude/config.json\"))
         }
     }
+
+    #[cfg(not(any(target_os = \"macos\", target_os = \"windows\", target_os = \"linux\", target_os = \"freebsd\", target_os = \"netbsd\", target_os = \"openbsd\", target_os = \"dragonfly\")))]
+    {
+        None
+    }
 }
```

## Discovery context

Hit while building `mcp_agent_mail_rust` (which depends on fastmcp_rust) on FreeBSD 15.0-RELEASE-p5 with `cargo build --release --no-default-features --features portable`. After applying this patch, the workspace compiles cleanly. The fix is the only fastmcp-side change required for FreeBSD support; the rest of the crate already cfg-gates correctly.

## Behavior matrix

| target_os | Before this PR | After this PR |
|---|---|---|
| macos | works | unchanged |
| windows | works | unchanged |
| linux | works | unchanged |
| freebsd | compile error | returns linux-style path |
| netbsd / openbsd / dragonfly | compile error | returns linux-style path |
| (other) | compile error | returns `None` |

## Verification

- FreeBSD 15: workspace builds cleanly with `--features portable` (verified building `mcp_agent_mail_rust`)
- Linux/macOS/Windows: no behavior change — same gated branch fires as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)